### PR TITLE
tech: prevent accidental usage of wrong record accessors

### DIFF
--- a/src/main/java/com/gw2auth/oauth2/server/repository/gw2account/Gw2AccountWithOptionalApiTokenEntity.java
+++ b/src/main/java/com/gw2auth/oauth2/server/repository/gw2account/Gw2AccountWithOptionalApiTokenEntity.java
@@ -8,12 +8,14 @@ import java.util.Optional;
 public record Gw2AccountWithOptionalApiTokenEntity(@Embedded.Empty(prefix = "acc_") Gw2AccountEntity account,
                                                    @Embedded.Nullable(prefix = "tk_") Gw2AccountApiTokenEntity token) {
 
+    /** @deprecated Use {@link #optionalToken()} instead */
+    @Deprecated
     @Override
     public Gw2AccountApiTokenEntity token() {
         throw new UnsupportedOperationException();
     }
 
-    public Optional<Gw2AccountApiTokenEntity> tokenOptional() {
+    public Optional<Gw2AccountApiTokenEntity> optionalToken() {
         return Optional.ofNullable(this.token);
     }
 }

--- a/src/main/java/com/gw2auth/oauth2/server/service/gw2account/Gw2AccountServiceImpl.java
+++ b/src/main/java/com/gw2auth/oauth2/server/service/gw2account/Gw2AccountServiceImpl.java
@@ -112,7 +112,7 @@ public class Gw2AccountServiceImpl implements Gw2AccountService, Clocked {
 
     private static Gw2AccountWithOptionalApiToken mapWithOptionalToken(Gw2AccountWithOptionalApiTokenEntity entity) {
         final Gw2Account account = Gw2Account.fromEntity(entity.account());
-        final Gw2AccountApiToken apiToken =  entity.tokenOptional()
+        final Gw2AccountApiToken apiToken =  entity.optionalToken()
                 .map(Gw2AccountApiToken::fromEntity)
                 .orElse(null);
 

--- a/src/main/java/com/gw2auth/oauth2/server/service/gw2account/Gw2AccountWithOptionalApiToken.java
+++ b/src/main/java/com/gw2auth/oauth2/server/service/gw2account/Gw2AccountWithOptionalApiToken.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 public record Gw2AccountWithOptionalApiToken(Gw2Account account, Gw2AccountApiToken apiToken) {
 
+    /** @deprecated Use {@link #optionalApiToken()} instead */
+    @Deprecated
     @Override
     public Gw2AccountApiToken apiToken() {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
Also renamed `tokenOptional` for consistency.