### PR TITLE
tech: use javac's `--release` flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <start-class>com.gw2auth.oauth2.server.Application</start-class>
     </properties>


### PR DESCRIPTION
Source & target compatibility have been effectively obsolete since Java 9.