### PR TITLE
chore: add Dependabot configuration for GHA

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "build"
+    groups:
+      "@actions/artifacts":
+        patterns:
+          - "actions/deploy-pages"
+          - "actions/download-artifact"
+          - "actions/upload-artifact"
+          - "actions/upload-pages-artifact"


### PR DESCRIPTION
You might want to adjust labels and change the commit prefix. Here's what I typically use:

```yaml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "daily"
    open-pull-requests-limit: 20
    commit-message:
      prefix: "build"
    labels:
      - "a:chore"
      - "in:build"
      - "in:dependencies"
    groups:
      "@actions/artifacts":
        patterns:
          - "actions/deploy-pages"
          - "actions/download-artifact"
          - "actions/upload-artifact"
          - "actions/upload-pages-artifact"
```